### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.5 (2020-03-19)
+
 ### 0.1.4 (2020-03-19)
 
 ### 0.1.3 (2020-03-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A tiny boolean function minimizer",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## <small>0.1.4 (2020-03-19)</small>

* ci: properly use another token for tagging ([a1657ab](https://github.com/yanana/requin/commit/a1657ab))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yanana/requin/16)
<!-- Reviewable:end -->
