### PR TITLE
Release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.7 (2020-03-25)
+
 ### 0.1.6 (2020-03-19)
 
 ### 0.1.5 (2020-03-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A tiny boolean function minimizer",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## <small>0.1.6 (2020-03-25)</small>

* build(deps): bump relude from 0.57.1 to 0.58.0 ([108a0a5](https://github.com/yanana/requin/commit/108a0a5))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yanana/requin/19)
<!-- Reviewable:end -->
