### PR TITLE
Release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.1.8 (2021-05-11)
+
 ### 0.1.7 (2020-03-25)
 
 ### 0.1.6 (2020-03-19)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "requin",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A tiny boolean function minimizer",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
## <small>0.1.7 (2021-05-11)</small>

* build(deps): bump lodash from 4.17.20 to 4.17.21 ([1a4614d](https://github.com/yanana/requin/commit/1a4614d))